### PR TITLE
fix: extract JSON from non-JSON strings

### DIFF
--- a/src/clone-npm-pkg.js
+++ b/src/clone-npm-pkg.js
@@ -15,7 +15,11 @@ const run = function(origdir) {
     if (result.status !== 0) {
       return Promise.resolve({result: 'fail', info: `\n${result.out}`});
     }
-    const packOutput = JSON.parse(result.stdout);
+
+    const jsonRegex = /\[(.|\n)*\]$/;
+    const jsonString = (result.stdout).match(jsonRegex)[0];
+
+    const packOutput = JSON.parse(jsonString);
 
     return Promise.all(packOutput.map((output) => {
       return Promise.all(output.files.map((file) => Promise.resolve().then(function() {

--- a/src/clone-npm-pkg.js
+++ b/src/clone-npm-pkg.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const shell = require('shelljs');
 const promiseSpawn = require('./promise-spawn.js');
 const exitHook = require('exit-hook');
+const getParsedJsonFromOutput = require('./utils');
 
 const run = function(origdir) {
   const tempdir = path.join(shell.tempdir(), crypto.randomBytes(20).toString('hex'));
@@ -16,10 +17,7 @@ const run = function(origdir) {
       return Promise.resolve({result: 'fail', info: `\n${result.out}`});
     }
 
-    const jsonRegex = /\[(.|\n)*\]$/;
-    const jsonString = (result.stdout).match(jsonRegex)[0];
-
-    const packOutput = JSON.parse(jsonString);
+    const packOutput = getParsedJsonFromOutput(result.stdout);
 
     return Promise.all(packOutput.map((output) => {
       return Promise.all(output.files.map((file) => Promise.resolve().then(function() {

--- a/src/clone-npm-pkg.js
+++ b/src/clone-npm-pkg.js
@@ -3,7 +3,7 @@ const crypto = require('crypto');
 const shell = require('shelljs');
 const promiseSpawn = require('./promise-spawn.js');
 const exitHook = require('exit-hook');
-const getParsedJsonFromOutput = require('./utils');
+const {getParsedJsonFromOutput} = require('./utils');
 
 const run = function(origdir) {
   const tempdir = path.join(shell.tempdir(), crypto.randomBytes(20).toString('hex'));

--- a/src/clone-npm-pkg.js
+++ b/src/clone-npm-pkg.js
@@ -16,7 +16,6 @@ const run = function(origdir) {
     if (result.status !== 0) {
       return Promise.resolve({result: 'fail', info: `\n${result.out}`});
     }
-
     const packOutput = getParsedJsonFromOutput(result.stdout);
 
     return Promise.all(packOutput.map((output) => {

--- a/src/pack-install.js
+++ b/src/pack-install.js
@@ -4,6 +4,7 @@ const promiseSpawn = require('./promise-spawn.js');
 const exitHook = require('exit-hook');
 const shell = require('shelljs');
 const fs = require('fs');
+const getParsedJsonFromOutput = require('./utils');
 
 const packInstall = function(pkgdir) {
   return Promise.resolve().then(function() {
@@ -33,9 +34,8 @@ const packInstall = function(pkgdir) {
         if (pack.status !== 0) {
           return Promise.reject(`npm pack failed:\n${pack.out}`);
         }
-        const jsonRegex = /\[(.|\n)*\]$/;
-        const jsonString = (pack.stdout).match(jsonRegex)[0];
-        const tarball = JSON.parse(jsonString)[0].filename;
+
+        const tarball = getParsedJsonFromOutput(pack.stdout)[0].filename;
 
         return promiseSpawn('npm', [
           'i',

--- a/src/pack-install.js
+++ b/src/pack-install.js
@@ -33,7 +33,9 @@ const packInstall = function(pkgdir) {
         if (pack.status !== 0) {
           return Promise.reject(`npm pack failed:\n${pack.out}`);
         }
-        const tarball = JSON.parse(pack.stdout)[0].filename;
+        const jsonRegex = /\[(.|\n)*\]$/;
+        const jsonString = (pack.stdout).match(jsonRegex)[0];
+        const tarball = JSON.parse(jsonString)[0].filename;
 
         return promiseSpawn('npm', [
           'i',

--- a/src/pack-install.js
+++ b/src/pack-install.js
@@ -4,7 +4,7 @@ const promiseSpawn = require('./promise-spawn.js');
 const exitHook = require('exit-hook');
 const shell = require('shelljs');
 const fs = require('fs');
-const getParsedJsonFromOutput = require('./utils');
+const { getParsedJsonFromOutput } = require('./utils');
 
 const packInstall = function(pkgdir) {
   return Promise.resolve().then(function() {

--- a/src/pack-install.js
+++ b/src/pack-install.js
@@ -4,7 +4,7 @@ const promiseSpawn = require('./promise-spawn.js');
 const exitHook = require('exit-hook');
 const shell = require('shelljs');
 const fs = require('fs');
-const { getParsedJsonFromOutput } = require('./utils');
+const {getParsedJsonFromOutput} = require('./utils');
 
 const packInstall = function(pkgdir) {
   return Promise.resolve().then(function() {
@@ -34,7 +34,6 @@ const packInstall = function(pkgdir) {
         if (pack.status !== 0) {
           return Promise.reject(`npm pack failed:\n${pack.out}`);
         }
-
         const tarball = getParsedJsonFromOutput(pack.stdout)[0].filename;
 
         return promiseSpawn('npm', [

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,13 @@
+const jsonRegex = /\[(.|\n)*\]$/;
+
+const getParsedJsonFromOutput = function(stdout) {
+  const jsonString = (stdout).match(jsonRegex)[0];
+
+  try {
+    return JSON.parse(jsonString);
+  } catch (e) {
+    return null;
+  }
+};
+
+module.exports = getParsedJsonFromOutput;

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,4 +10,4 @@ const getParsedJsonFromOutput = function(stdout) {
   }
 };
 
-module.exports = getParsedJsonFromOutput;
+module.exports = {getParsedJsonFromOutput};


### PR DESCRIPTION
The latest version of the husky library appends some messages like "> husky install" or "husky - Git hooks installed" on install. Since videojs-generator-verify expects JSON, these unexpected messages and special characters cause 
`vjsverify: An internal error occurred SyntaxError: Unexpected token > in JSON at position 0` error.

The PR adds a regEx to extract the JSON from the text.